### PR TITLE
Resolve Issue of Multiple Drafts for Same Message Thread

### DIFF
--- a/email_handler.py
+++ b/email_handler.py
@@ -13,16 +13,20 @@ def get_unread_emails(service):
 
         # Extract the thread IDs of the drafts
         draft_thread_ids = [draft['message']['threadId'] for draft in drafts]
+        logging.info(f'Draft thread IDs: {draft_thread_ids}')
 
-        # Build the query for fetching unread emails
-        query = 'is:unread'
-        for thread_id in draft_thread_ids:
-            query += f' -threadId:{thread_id}'
+        # Fetch all unread emails
+        results = service.users().messages().list(userId='me', q='is:unread').execute()
+        all_unread_emails = results.get('messages', [])
+        all_unread_email_ids = [email['threadId'] for email in all_unread_emails]
+        logging.info(f'All unread email IDs: {all_unread_email_ids}')
 
-        # Fetch the unread emails
-        results = service.users().messages().list(userId='me', q=query).execute()
-        messages = results.get('messages', [])
-        return messages
+        # Filter out the unread emails that belong to threads with drafts
+        filtered_unread_emails = [email for email in all_unread_emails if email['threadId'] not in draft_thread_ids]
+        filtered_unread_email_ids = [email['threadId'] for email in filtered_unread_emails]
+        logging.info(f'Filtered unread email IDs: {filtered_unread_email_ids}')
+
+        return filtered_unread_emails
     except Exception as e:
         logging.error(f'An error occurred: {e}')
         return None


### PR DESCRIPTION
This PR addresses the bug reported in Issue #1 , where the application was creating multiple drafts for the same message thread on each loop.

To prevent this, we've modified the `get_unread_emails` function to only fetch unread emails from threads that don't already have a draft. This was achieved by getting a list of all drafts, extracting the thread IDs from these drafts, and excluding these thread IDs when fetching unread emails.

Please note the following limitations:
- The Gmail API's `users().messages().list()` method only returns the first 100 messages that match the query. If there are more than 100 unread emails, some of them might not be processed.
- If a new email arrives in a thread after the draft has been created but before the user sends the draft, the new email won't be included in the draft.

These limitations were deemed acceptable for the current use-case of the application.