### PR TITLE
Filter Emails More Precisely Before Drafting Replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Email Auto-ReplAI
 
-Email Auto-ReplAI is a Python tool that uses AI to automate drafting responses to unread Gmail messages, streamlining email management tasks. It can use either a local AI model or the OpenAI API based on your configuration.
+Email Auto-ReplAI is a Python tool that uses AI to automate drafting responses to unread Gmail messages, streamlining email management tasks. It creates drafts for messages specifically addressed to the user, disregarding messages where the user is only CCed or BCCed. Additionally, the application does not generate drafts for messages from or reply-to a noreply or donotreply address and messages with a List-Unsubscribe header. The application can use either a local AI model or the OpenAI API based on your configuration.
 
 ## Setup
 
@@ -29,9 +29,10 @@ The script performs the following steps in a loop:
 
 1. Connects to Gmail using OAuth 2.0.
 2. Fetches unread emails.
-3. Parses the email content.
-4. Sends the email content to either a local AI model or the OpenAI API, based on your configuration, to generate a response.
-5. Creates a draft in Gmail with the generated response.
+3. Filters emails based on the specified rules (directly addressed to user, no List-Unsubscribe header, and not from a noreply/donotreply address).
+4. Parses the filtered email content.
+5. Sends the email content to either a local AI model or the OpenAI API, based on your configuration, to generate a response.
+6. Creates a draft in Gmail with the generated response.
 
 The script sleeps for an hour between each loop.
 

--- a/main.py
+++ b/main.py
@@ -41,6 +41,9 @@ def main():
         if gmail_service is None:
             sys.exit(1)
 
+        # Get the user's email address
+        user_email_address = gmail_service.users().getProfile(userId='me').execute()['emailAddress']
+
         while True:
             try:
                 # Get unread emails
@@ -52,7 +55,7 @@ def main():
                 for email in emails:
                     try:
                         # Extract the email content
-                        email_data = email_handler.parse_email_content(gmail_service, email)
+                        email_data = email_handler.parse_email_content(gmail_service, email, user_email_address)
                         if email_data is None:
                             continue
 


### PR DESCRIPTION
This Pull Request introduces several updates to the email filtering process to improve the specificity of the application's responses and reduce unwanted drafts. The modifications ensure that the application adheres more accurately to the user's instructions.

The main changes introduced are:

1. Addressed to User: The application now only drafts replies for emails that are directly addressed to the user. It checks the 'To' field of the incoming email against the user's address and skips over any that don't match.
2. List-Unsubscribe Header: The application now checks for the presence of a 'List-Unsubscribe' header in incoming emails. If it finds this header, it interprets the email as being from a mailing list and does not draft a reply.
3. No-Reply Addresses: The application checks the 'From' and 'Reply-to' fields of incoming emails for common no-reply addresses, including 'noreply@', 'no-reply@', 'donotreply@', and 'do-not-reply@'. If it finds a match, it does not draft a reply.

This PR helps to make the application's responses more precise and user-specific, reducing the number of unnecessary or unwanted drafts created. The updates should improve the overall user experience.